### PR TITLE
Add 2017 Talks

### DIFF
--- a/recordings.md
+++ b/recordings.md
@@ -5,7 +5,26 @@ title: Recordings - !!Con 2017
 
 ## Recordings
 
-There's nothing here yet!  Stay tuned for our 2017 recordings.  In the
-meantime, you may be interested in the recordings from !!Con
-[2016](2016/recordings.html), [2015](2015/recordings.html), or
-[2014](2014/recordings.html).
+<section id="talk_container"></section>
+
+<div id="talk-template" style="display:none" class="talk">
+  <h3 class="talk-info"></h3>
+  <div class="talk-youtube-thumb"></div>
+  <div class="talk-youtube"></div>
+  <div class="talk-embed"></div>
+  <div class="talk-transcript"></div>
+  <div style="clear:both"></div>
+</div>
+
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script type="text/javascript" src="js/recordings.js"></script>
+<script defer="defer">
+  jQuery.getJSON('talks.json', function(talks) {
+    generateTalks(
+      '#talk-template',
+      '#talk_container',
+      talks,
+      "./2017-transcripts/"
+    );
+  });
+</script>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -330,3 +330,28 @@ table, caption, tbody, tfoot, thead, tr, th, td {
     font-size: 100%;
     margin: 0;
 }
+
+/* recordings */
+.talk-info {
+  margin-bottom: .5em;
+}
+
+.talk-info .speaker {
+  text-align: initial;
+  padding: 0;
+  padding-bottom: 0.5em;
+}
+
+.talk-info .talk-title {
+  display: block;
+}
+
+.talk-embed a {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.talk-youtube-thumb {
+  float: left;
+  margin-right: 1em;
+}

--- a/talks.json
+++ b/talks.json
@@ -1,0 +1,219 @@
+[
+  {
+    "author": "Karen Sandler",
+    "authorslug": "karen-sandler",
+    "title": "Keynote - Cyborgs Unite!",
+    "youtube": "z2R97v9n4pI",
+    "transcript": false
+  },
+  {
+    "author": "Charles Chamberlain",
+    "authorslug": "charles-chamberlain",
+    "title": "Serious programming with jq?! A practical and purely functional programming language!",
+    "youtube": "PS_9pyIASvQ",
+    "transcript": false
+  },
+  {
+    "author": "Aaron Levin",
+    "authorslug": "aaron-levin",
+    "title": "Finding Friends in High Dimensions: Locality-Sensitive Hashing For Fun and Friendliness!",
+    "youtube": "kKRvEJrvvso",
+    "transcript": false
+  },
+  {
+    "author": "Jan Mitsuko Cash",
+    "authorslug": "jan-mitsuko-cash",
+    "title": "What Alien Invaders, Birds, and Computer Simulations have in Common: Flocking!!",
+    "youtube": "Q52oYMO962w",
+    "transcript": false
+  },
+  {
+    "author": "Jason McIntosh",
+    "authorslug": "jason-mcintosh",
+    "title": "I wrote to a dead address in a deleted PDF and now I know where all the airplanes are!!",
+    "youtube": "CGrwWrsVAFs",
+    "transcript": false
+  },
+  {
+    "author": "Andrew Plotkin",
+    "authorslug": "andrew-plotkin",
+    "title": "Glk! A Universal User Interface! for Interactive Fiction!",
+    "youtube": "FhVob_sRqQk",
+    "transcript": false
+  },
+  {
+    "author": "Scott Vokes",
+    "authorslug": "scott-vokes",
+    "title": "How do Keyboards Work? HIDing, in Plain Sight!!",
+    "youtube": "1v4Qwg41GCg",
+    "transcript": false
+  },
+  {
+    "author": "Bomani McClendon",
+    "authorslug": "bomani-mcclendon",
+    "title": "Making Mushrooms Glow!",
+    "youtube": "T75FvUDirNM",
+    "transcript": false
+  },
+  {
+    "author": "Ewan Dennis",
+    "authorslug": "ewan-dennis",
+    "title": "Why So Loud! Geeking Out On Airline Data, Physics And Mapping",
+    "youtube": "DqBUovYR7Og",
+    "transcript": false
+  },
+  {
+    "author": "Christian Joudrey",
+    "authorslug": "christian-joudrey",
+    "title": "Writing NES Games! with Assembly!!",
+    "youtube": "IbS7uEsHV_A",
+    "transcript": false
+  },
+  {
+    "author": "Jean Cochrane",
+    "authorslug": "jean-cochrane",
+    "title": "The TOP 5 Queer Feminist Cyberpunk Manifestos!",
+    "youtube": "5GiQovHaT_g",
+    "transcript": false
+  },
+  {
+    "author": "Evan Jones",
+    "authorslug": "evan-jones",
+    "title": "Corruption in the Data Center! TCP can fail to keep your data safe!",
+    "youtube": "OKg9RI6IkV8",
+    "transcript": false
+  },
+  {
+    "author": "Joel Potischman",
+    "authorslug": "joel-potischman",
+    "title": "What the heck time is it?!?",
+    "youtube": "MDmNvVG9AnQ",
+    "transcript": false
+  },
+  {
+    "author": "Kevin Chen",
+    "authorslug": "kevin-chen",
+    "title": "HDR Photography in Microsoft Excel?!",
+    "youtube": "bkQJdaGGVM8",
+    "transcript": false
+  },
+  {
+    "author": "Mark Dominus",
+    "authorslug": "mark-dominus",
+    "title": "I got the computer to find words with good anagrams and throw away the boring ones!!",
+    "youtube": "VXW_V5iishY",
+    "transcript": false
+  },
+  {
+    "author": "Limor Fried",
+    "authorslug": "limor-fried",
+    "title": "Keynote - We Are What We Celebrate: The Joy, Excitement, and Surprise of Who is Making Things",
+    "youtube": "w9XsWeU5PZA",
+    "transcript": false
+  },
+  {
+    "author": "Jes Wolfe!",
+    "authorslug": "jes-wolfe!",
+    "title": "Synthesizing Video and Turning it into Music!!",
+    "youtube": "nwsg-ZTRRoI",
+    "transcript": false
+  },
+  {
+    "author": "Mahtab Sabet",
+    "authorslug": "mahtab-sabet",
+    "title": "PUSH THE BUTTON! 🔴 Designing a fun game where the only input is a BIG RED BUTTON! 🔴 !!!",
+    "youtube": "KqEc2Ek4GzA",
+    "transcript": false
+  },
+  {
+    "author": "Paul Frazee",
+    "authorslug": "paul-frazee",
+    "title": "Simulated Gravity Comes from Within!!",
+    "youtube": "BhNw5_UyAhU",
+    "transcript": false
+  },
+  {
+    "author": "Richard Herrington",
+    "authorslug": "richard-harrington",
+    "title": "BEEP!! See AppleSoft BASIC and 6502 assembly language written on an actual Apple IIc from the 80s! Fresh on startup with no software installed!",
+    "youtube": "DY4t9IHFD4E",
+    "transcript": false
+  },
+  {
+    "author": "David Turner",
+    "authorslug": "david-turner",
+    "title": "Om! Nom! Nash!",
+    "youtube": "RHg2JIvoaq0",
+    "transcript": false
+  },
+  {
+    "author": "Julian Squires",
+    "authorslug": "julian-squires",
+    "title": "The emoji that Killed Chrome!!",
+    "youtube": "UE-fJjMasec",
+    "transcript": false
+  },
+  {
+    "author": "Yomna Nasser",
+    "authorslug": "yomna-nasser",
+    "title": "Islamic Geometry: Hankin’s Polygons in Contact Algorithm!!!",
+    "youtube": "ld4gpQnaziU",
+    "transcript": false
+  },
+  {
+    "author": "Tara Vancil",
+    "authorslug": "tara-vancil",
+    "title": "How Merkle Trees Enable the Decentralized Web!",
+    "youtube": "3giNelTfeAk",
+    "transcript": false
+  },
+  {
+    "author": "Lisa Ballard",
+    "authorslug": "lisa-ballard",
+    "title": "Where Are All the Space Robots?!",
+    "youtube": "cfNErhM3vXI",
+    "transcript": false
+  },
+  {
+    "author": "Ruchir Khaitan",
+    "authorslug": "ruchir-khaitan",
+    "title": "Interpolation Search Can Be Fast, in Some Situations, Sometimes, If You Try!",
+    "youtube": "RJU2cXvQ9po",
+    "transcript": false
+  },
+  {
+    "author": "Michael Kwan",
+    "authorslug": "michael-kwan",
+    "title": "No battery, no (watch) life!!",
+    "youtube": "2c1I7-qWWWI",
+    "transcript": false
+  },
+  {
+    "author": "Walt Mankowski",
+    "authorslug": "walt-mankowski",
+    "title": "A Punch Card ate my Program!",
+    "youtube": "PF6JEK0BpPU",
+    "transcript": false
+  },
+  {
+    "author": "Mindy Preston",
+    "authorslug": "mindy-preston",
+    "title": "DHCP: IT’S MOSTLY YELLING!!",
+    "youtube": "enRY9jd0IJw",
+    "transcript": false
+  },
+  {
+    "author": "Geoffrey Litt",
+    "authorslug": "geoffrey-litt",
+    "title": "ENHANCE! Upscaling Images with Neural Networks",
+    "youtube": "RhUmSeko1ZE",
+    "transcript": false
+  },
+  {
+    "author": "Erty Seidel",
+    "authorslug": false,
+    "title": "Closing Remarks: The Origin Story",
+    "youtube": "gdIrdkSIND8",
+    "transcript": false
+  }
+]


### PR DESCRIPTION
Adds 2017 recordings from the Confreaks channel, albeit using the same machinery as previous years; I suspect Jekyll's `_data` files and templating could reproduce much of the functionality of the existing JS.

Minor CSS tweaks due to the numerous lengthy talk names this year.

Haven't labelled Erty's closing remarks as a surprise talk (I see this is how it was described in 2016)—I wasn't there, so don't know whether it was or was not a surprise!

I haven't listed Nick Sullivan's talk: there doesn't seem to be a recording available.