### PR TITLE
Change email address for code of conduct form submission

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -107,7 +107,7 @@ experiencing harassment to feel safe for the duration of the
 conference. We value your attendance.
         
 ## Report a violation (with or without your name)
-<form action="https://formspree.io/nabil.hassein@gmail.com" method="POST">
+<form action="https://formspree.io/ahmad19526@gmail.com" method="POST">
 
 <label for="code of conduct violation">Code of Conduct violation </label>
 <textarea type="text" name="code of conduct violation" rows="5" cols="80"></textarea>

--- a/conduct.md
+++ b/conduct.md
@@ -107,7 +107,7 @@ experiencing harassment to feel safe for the duration of the
 conference. We value your attendance.
         
 ## Report a violation (with or without your name)
-<form action="https://formspree.io/ahmad19526@gmail.com" method="POST">
+<form action="https://formspree.io/simplyahmazing@gmail.com" method="POST">
 
 <label for="code of conduct violation">Code of Conduct violation </label>
 <textarea type="text" name="code of conduct violation" rows="5" cols="80"></textarea>


### PR DESCRIPTION
I received an email from formspree today that I will shortly share with the listserv.
I don't believe any action is actually required, 
but it was a reminder I wanted to pass along before forgetting again that
currently, it is my personal email set to receive notifications about
code of conduct reporting from the third-party form embedded on http://bangbangcon.com/conduct.html.

I arbitrarily picked on Ahmed as the updated recipient,
but obviously it's up to y'all who wants to take on receiving these submissions.
(I remember considering sending them to the entire bangbangcon-archive listserv,
but that is not allowed under the only-members-can-email setting we were using at the time,
and which I believe is still in effect.)