### PR TITLE
Fix insecure form submission on the homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -69,7 +69,7 @@ for our mailing list below.  We send about four or five emails per year for impo
 
 <!-- Begin MailChimp Signup Form -->
 <div id="mc_embed_signup">
-<form action="http://bangbangcon.us3.list-manage.com/subscribe/post?u=37b924b9d7d71dc7aa1a52b4c&amp;id=9f9ec7c469" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" style="background-color: inherit;" novalidate>
+<form action="https://bangbangcon.us3.list-manage.com/subscribe/post?u=37b924b9d7d71dc7aa1a52b4c&amp;id=9f9ec7c469" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" style="background-color: inherit;" novalidate>
 <div class="mc-field-group">
 <label for="mce-EMAIL">Email:</label>
 <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder='your email address'>


### PR DESCRIPTION
The HTTP version just redirects to the HTTPS version anyway. (A temporary redirect, but still.)

Note that browsers also warn users about this kind of insecure form submission.